### PR TITLE
Rigid bodies publisher 

### DIFF
--- a/mocap_vicon_driver/include/mocap_vicon_driver/mocap_vicon_driver.hpp
+++ b/mocap_vicon_driver/include/mocap_vicon_driver/mocap_vicon_driver.hpp
@@ -56,7 +56,7 @@ public:
 
 protected:
   ViconDataStreamSDK::CPP::Client client;
-  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::Markers>::SharedPtr marker_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::Markers>::SharedPtr markers_pub_;
   rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::RigidBodies>::SharedPtr rigid_bodies_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/mocap_vicon_driver/include/mocap_vicon_driver/mocap_vicon_driver.hpp
+++ b/mocap_vicon_driver/include/mocap_vicon_driver/mocap_vicon_driver.hpp
@@ -31,6 +31,7 @@
 
 #include "mocap_msgs/msg/marker.hpp"
 #include "mocap_msgs/msg/markers.hpp"
+#include "mocap_msgs/msg/rigid_bodies.hpp"
 
 namespace mocap_vicon_driver
 {
@@ -56,6 +57,7 @@ public:
 protected:
   ViconDataStreamSDK::CPP::Client client;
   rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::Markers>::SharedPtr marker_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::RigidBodies>::SharedPtr rigid_bodies_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   std::string stream_mode_;

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -130,6 +130,8 @@ void ViconDriverNode::process_frame()
           _Output_GetMarkerGlobalTranslation =
           client.GetMarkerGlobalTranslation(this_subject_name, this_marker.marker_name);
 
+        // if subject is not in the scene the position will be empty (0, 0, 0)
+        // it is also happens when one marker of the subject is lost or not being seen
         this_marker.translation.x = _Output_GetMarkerGlobalTranslation.Translation[0]/1000.0;
         this_marker.translation.y = _Output_GetMarkerGlobalTranslation.Translation[1]/1000.0;
         this_marker.translation.z = _Output_GetMarkerGlobalTranslation.Translation[2]/1000.0;
@@ -148,8 +150,8 @@ void ViconDriverNode::process_frame()
           client.GetSegmentGlobalRotationQuaternion(this_subject_name, this_segment_name);
 
         mocap_msgs::msg::RigidBody this_segment;
-        // TODO: this_segment_name is 'root', subject name might be better
-        this_segment.rigid_body_name = this_segment_name;
+        std::string rigid_body_name = this_subject_name + "." + this_segment_name;
+        this_segment.rigid_body_name = rigid_body_name;
         this_segment.pose.position.x = trans.Translation[0]/1000.0;
         this_segment.pose.position.y = trans.Translation[1]/1000.0;
         this_segment.pose.position.z = trans.Translation[2]/1000.0;

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -57,6 +57,8 @@ void ViconDriverNode::set_settings_vicon()
     Enum2String(_Output_GetAxisMapping.ZAxis).c_str());
 
   client.EnableSegmentData();
+  client.EnableMarkerData();
+  client.EnableUnlabeledMarkerData();
 
   RCLCPP_INFO(
     get_logger(), "IsSegmentDataEnabled? %s",
@@ -103,12 +105,6 @@ void ViconDriverNode::process_frame()
       "GetFrame succeeded. Got frame [%d] at rate [%3.3f]", OutputFrameNum.FrameNumber,
       OutputFrameRate.FrameRateHz);
 
-    // TODO: part of vicon settings, move to on_activate?
-    client.EnableSegmentData();
-    client.EnableMarkerData();
-    client.EnableUnlabeledMarkerData();
-
-    rclcpp::Duration frame_delay = rclcpp::Duration(client.GetLatencyTotal().Total);
 
     mocap_msgs::msg::RigidBodies rigid_bodies_msg;
     rigid_bodies_msg.header.stamp = now();  // TODO: add client.GetLatencyTotal() ?

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -72,7 +72,6 @@ void ViconDriverNode::set_settings_vicon()
     _Output_GetVersion.Minor,
     _Output_GetVersion.Point
   );
-
 }
 
 // In charge of the transition of the lifecycle node
@@ -90,7 +89,7 @@ void ViconDriverNode::control_stop(const mocap_control_msgs::msg::Control::Share
 // In charge of get the Vicon information and convert it to vicon_msgs
 void ViconDriverNode::process_frame()
 {
-  if (marker_pub_->get_subscription_count() == 0 && rigid_bodies_pub_->get_subscription_count() == 0) {
+  if (markers_pub_->get_subscription_count() == 0 && rigid_bodies_pub_->get_subscription_count() == 0) {
     return;
   }
 
@@ -137,7 +136,7 @@ void ViconDriverNode::process_frame()
 
         markers_msg.markers.push_back(this_marker);
       }
-      marker_pub_->publish(markers_msg);
+      markers_pub_->publish(markers_msg);
 
       unsigned int num_subject_segments = client.GetSegmentCount(this_subject_name).SegmentCount;
       for (unsigned int SegmentIndex = 0; SegmentIndex < num_subject_segments; ++SegmentIndex) {
@@ -176,7 +175,7 @@ ViconDriverNode::on_configure(const rclcpp_lifecycle::State &)
 {
   initParameters();
 
-  marker_pub_ = create_publisher<mocap_msgs::msg::Markers>("/markers", rclcpp::QoS(1000));
+  markers_pub_ = create_publisher<mocap_msgs::msg::Markers>("/markers", rclcpp::QoS(1000));
   rigid_bodies_pub_ = create_publisher<mocap_msgs::msg::RigidBodies>("/rigid_bodies", rclcpp::QoS(1000));
 
   auto stat = client.Connect(host_name_).Result;
@@ -193,7 +192,7 @@ ViconDriverNode::on_configure(const rclcpp_lifecycle::State &)
 CallbackReturnT
 ViconDriverNode::on_activate(const rclcpp_lifecycle::State &)
 {
-  marker_pub_->on_activate();
+  markers_pub_->on_activate();
   rigid_bodies_pub_->on_activate();
 
   set_settings_vicon();
@@ -207,7 +206,7 @@ ViconDriverNode::on_activate(const rclcpp_lifecycle::State &)
 CallbackReturnT
 ViconDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
 {
-  marker_pub_->on_deactivate();
+  markers_pub_->on_deactivate();
   rigid_bodies_pub_->on_deactivate();
 
   client.DisableSegmentData();

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -110,10 +110,12 @@ void ViconDriverNode::process_frame()
 
     mocap_msgs::msg::RigidBodies rigid_bodies_msg;
     rigid_bodies_msg.header.stamp = now();  // TODO: add client.GetLatencyTotal() ?
+    rigid_bodies_msg.header.frame_id = frame_id_;
     rigid_bodies_msg.frame_number = frameCount_++;
 
     mocap_msgs::msg::Markers markers_msg;
     markers_msg.header.stamp = now();  // TODO: add client.GetLatencyTotal() ?
+    rigid_bodies_msg.header.frame_id = frame_id_;
     markers_msg.frame_number = frameCount_++;
 
     unsigned int SubjectCount = client.GetSubjectCount().SubjectCount;

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -151,7 +151,6 @@ void ViconDriverNode::process_frame()
         mocap_msgs::msg::RigidBody this_segment;
         // TODO: this_segment_name is 'root', subject name might be better
         this_segment.rigid_body_name = this_segment_name;
-        // TODO: move markers to rigid body
         this_segment.pose.position.x = trans.Translation[0]/1000.0;
         this_segment.pose.position.y = trans.Translation[1]/1000.0;
         this_segment.pose.position.z = trans.Translation[2]/1000.0;
@@ -159,6 +158,7 @@ void ViconDriverNode::process_frame()
         this_segment.pose.orientation.y = rot.Rotation[1];
         this_segment.pose.orientation.z = rot.Rotation[2];
         this_segment.pose.orientation.w = rot.Rotation[3];
+        this_segment.markers = markers_msg.markers;
         rigid_bodies_msg.rigidbodies.push_back(this_segment);
       }
       rigid_bodies_pub_->publish(rigid_bodies_msg);

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -90,8 +90,7 @@ void ViconDriverNode::control_stop(const mocap_control_msgs::msg::Control::Share
 // In charge of get the Vicon information and convert it to vicon_msgs
 void ViconDriverNode::process_frame()
 {
-  // TODO: or other publisher rigid bodies
-  if (marker_pub_->get_subscription_count() == 0) {
+  if (marker_pub_->get_subscription_count() == 0 && rigid_bodies_pub_->get_subscription_count() == 0) {
     return;
   }
 
@@ -150,6 +149,7 @@ void ViconDriverNode::process_frame()
           client.GetSegmentGlobalRotationQuaternion(this_subject_name, this_segment_name);
 
         mocap_msgs::msg::RigidBody this_segment;
+        // TODO: this_segment_name is 'root', subject name might be better
         this_segment.rigid_body_name = this_segment_name;
         // TODO: move markers to rigid body
         this_segment.pose.position.x = trans.Translation[0]/1000.0;

--- a/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
+++ b/mocap_vicon_driver/src/mocap_vicon_driver/mocap_vicon_driver.cpp
@@ -90,6 +90,7 @@ void ViconDriverNode::control_stop(const mocap_control_msgs::msg::Control::Share
 // In charge of get the Vicon information and convert it to vicon_msgs
 void ViconDriverNode::process_frame()
 {
+  // TODO: or other publisher rigid bodies
   if (marker_pub_->get_subscription_count() == 0) {
     return;
   }
@@ -105,6 +106,7 @@ void ViconDriverNode::process_frame()
       "GetFrame succeeded. Got frame [%d] at rate [%3.3f]", OutputFrameNum.FrameNumber,
       OutputFrameRate.FrameRateHz);
 
+    // rclcpp::Duration frame_delay = rclcpp::Duration(client.GetLatencyTotal().Total);
 
     mocap_msgs::msg::RigidBodies rigid_bodies_msg;
     rigid_bodies_msg.header.stamp = now();  // TODO: add client.GetLatencyTotal() ?
@@ -128,9 +130,9 @@ void ViconDriverNode::process_frame()
           _Output_GetMarkerGlobalTranslation =
           client.GetMarkerGlobalTranslation(this_subject_name, this_marker.marker_name);
 
-        this_marker.translation.x = _Output_GetMarkerGlobalTranslation.Translation[0];
-        this_marker.translation.y = _Output_GetMarkerGlobalTranslation.Translation[1];
-        this_marker.translation.z = _Output_GetMarkerGlobalTranslation.Translation[2];
+        this_marker.translation.x = _Output_GetMarkerGlobalTranslation.Translation[0]/1000.0;
+        this_marker.translation.y = _Output_GetMarkerGlobalTranslation.Translation[1]/1000.0;
+        this_marker.translation.z = _Output_GetMarkerGlobalTranslation.Translation[2]/1000.0;
 
         markers_msg.markers.push_back(this_marker);
       }
@@ -148,9 +150,9 @@ void ViconDriverNode::process_frame()
         mocap_msgs::msg::RigidBody this_segment;
         this_segment.rigid_body_name = this_segment_name;
         // TODO: move markers to rigid body
-        this_segment.pose.position.x = trans.Translation[0];
-        this_segment.pose.position.y = trans.Translation[1];
-        this_segment.pose.position.z = trans.Translation[2];
+        this_segment.pose.position.x = trans.Translation[0]/1000.0;
+        this_segment.pose.position.y = trans.Translation[1]/1000.0;
+        this_segment.pose.position.z = trans.Translation[2]/1000.0;
         this_segment.pose.orientation.x = rot.Rotation[0];
         this_segment.pose.orientation.y = rot.Rotation[1];
         this_segment.pose.orientation.z = rot.Rotation[2];


### PR DESCRIPTION
The PR includes these changes:
- New rigid_body publisher added
- Moved `client.EnableSegmentData()` and similar methods to `set_settings_vicon()`
- Fixed bug on translation unit, from millimeter to meter (see Vicon DataStream SDK Developer’s Guide page 5)
- Added frame from ros parameters to msg headers
- Modified processing frame condition: return only if both publishers don't have subscribers

I've tried to imitate `mocap4ros2_optitrack` package structure to keep readability between packages. Feel free to change whatever you consider relevant.

PS: I'm drafting the PR because I'm getting some empty frames which should be filtered. It might be fixed checking `Output_GetSegmentGlobalTranslation` output result. I'll be doing further tests next Friday and I'll update the PR after.

![Screenshot from 2023-11-01 12-37-49](https://github.com/MOCAP4ROS2-Project/mocap4ros2_vicon/assets/35956525/00feb9fa-3fdb-4980-b41c-c5efd754b083)
