### PR TITLE
Fix: Prevent marker accumulation in rigid body messages

### DIFF
--- a/mocap4r2_vicon_driver/src/mocap4r2_vicon_driver/mocap4r2_vicon_driver.cpp
+++ b/mocap4r2_vicon_driver/src/mocap4r2_vicon_driver/mocap4r2_vicon_driver.cpp
@@ -125,6 +125,8 @@ void ViconDriverNode::process_frame()
     for (unsigned int SubjectIndex = 0; SubjectIndex < SubjectCount; ++SubjectIndex) {
       std::string this_subject_name = client.GetSubjectName(SubjectIndex).SubjectName;
 
+      std::vector<mocap4r2_msgs::msg::Marker> subject_markers; // temp marker list for subject
+
       unsigned int num_subject_markers = client.GetMarkerCount(this_subject_name).MarkerCount;
       for (unsigned int MarkerIndex = 0; MarkerIndex < num_subject_markers; ++MarkerIndex) {
         mocap4r2_msgs::msg::Marker this_marker;
@@ -142,6 +144,8 @@ void ViconDriverNode::process_frame()
         this_marker.translation.z = _Output_GetMarkerGlobalTranslation.Translation[2] / 1000.0;
 
         markers_msg.markers.push_back(this_marker);
+
+        subject_markers.push_back(this_marker); // add marker to the subject
       }
 
       unsigned int num_subject_segments = client.GetSegmentCount(this_subject_name).SegmentCount;
@@ -164,7 +168,7 @@ void ViconDriverNode::process_frame()
         this_segment.pose.orientation.y = rot.Rotation[1];
         this_segment.pose.orientation.z = rot.Rotation[2];
         this_segment.pose.orientation.w = rot.Rotation[3];
-        this_segment.markers = markers_msg.markers;
+        this_segment.markers = subject_markers;
         rigid_bodies_msg.rigidbodies.push_back(this_segment);
       }
     }


### PR DESCRIPTION
### Description

This PR fixes an issue in multi‑subject tracking where the marker list for each rigid body is incorrectly accumulating markers from previously processed subjects within the same frame. As a result, a rigid body such as object2 would include its own markers **plus** all markers from object1. This cause incorrect data to be published on `/rigid_bodies` topic

### Bug Fix

The root cause is that a single marker vector is reused across subject iterations without being cleared, causing markers from earlier subjects to leak into later ones.

The fix introduces a new per‑subject vector (`subject_markers`) that is created fresh for each iteration. This ensures each rigid body receives a marker list containing only its own markers.

(The behavior of  `/markers` topic remains unchanged)